### PR TITLE
Typo: False RAG Entry Injection

### DIFF
--- a/data/techniques.yaml
+++ b/data/techniques.yaml
@@ -1984,7 +1984,7 @@
     \ augmented generation (RAG) database. Content designed to be interpreted as a\
     \ document by the large language model (LLM) used in the RAG system is included\
     \ in a data source being ingested into the RAG database. When RAG entry including\
-    \ the false document is retrieved the, the LLM is tricked into treating part of\
+    \ the false document is retrieved, the LLM is tricked into treating part of\
     \ the retrieved content as a false RAG result. \n\nBy including a false RAG document\
     \ inside of a regular RAG entry, it bypasses data monitoring tools. It also prevents\
     \ the document from being deleted directly. \n\nThe adversary may use discovered\


### PR DESCRIPTION
Hey folks, 

Was reading through Atlas and noticed a typo 

> When RAG entry including the false document is retrieved the, the LLM is tricked into treating part of the retrieved content as a false RAG result.

Just issuing a pull request to fix it! Apologies if I've missed a step or there is a easier way to get in touch. 

Thank you!